### PR TITLE
Feat: Add horizontal CC control to hand tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # Hand Tracking MIDI Controller
 
-This project uses your webcam to track your hand and convert its vertical position into MIDI notes, allowing you to play virtual instruments by moving your hand.
+This project uses your webcam to track your hand and convert its position into MIDI signals, allowing you to play and modulate virtual instruments in real-time.
 
-The project has been structured as a reusable Python module, and it includes a demonstration for both standard Python execution and use within a Jupyter Notebook.
+The project is structured as a reusable Python module and includes demonstrations for both standard Python execution and use within a Jupyter Notebook.
+
+## Features
+
+-   **Note Control (Y-axis):** The vertical position of your hand is mapped to a MIDI note (0-127). Move your hand up and down to play different notes.
+-   **Modulation Control (X-axis):** The horizontal position of your hand is mapped to a MIDI Control Change (CC) value. By default, it controls **CC #1 (Modulation)**, but it can be configured for other parameters.
+-   **Jupyter Notebook Integration:** Display the webcam feed and control the instrument directly within a Jupyter Notebook.
+-   **Configurable:** Easily change the MIDI port name and the CC control number.
 
 ## Project Structure
 
--   `hand_tracking_module.py`: The core module containing the `HandMusicController` class, which encapsulates all the logic for hand tracking and MIDI control.
--   `main.py`: An example script that imports the `HandMusicController` and runs the application in a standalone window.
--   `demo.ipynb`: A Jupyter Notebook that demonstrates how to use the `HandMusicController` for interactive use, displaying the webcam feed directly in the notebook.
--   `requirements.txt`: A list of Python dependencies required for the project.
+-   `hand_tracking_module.py`: The core module containing the `HandMusicController` class.
+-   `main.py`: An example script to run the application in a standalone window.
+-   `demo.ipynb`: A Jupyter Notebook that demonstrates interactive use.
+-   `requirements.txt`: A list of Python dependencies.
 
 ## Requirements
 
 *   Python 3.x
-*   The libraries listed in `requirements.txt`:
-    *   `opencv-python`
-    *   `mediapipe`
-    *   `mido`
-    *   `python-rtmidi`
-    *   `numpy`
-*   For the Jupyter Notebook demo, you will also need:
-    *   `jupyter`
-    *   `ipython`
+*   The libraries listed in `requirements.txt`.
+*   For the Jupyter Notebook demo: `jupyter` and `ipython`.
 
 ## Installation
 
@@ -35,51 +35,57 @@ The project has been structured as a reusable Python module, and it includes a d
 2.  **Install the dependencies:**
     ```bash
     pip install -r requirements.txt
-    # If you plan to run the notebook demo, also install jupyter
-    pip install jupyter ipython
     ```
 
 ## How to Use
 
-Before you start, you need to set up a virtual MIDI device to receive the notes from this application.
+### 1. MIDI Setup
 
-### MIDI Setup
+Before you start, you need a virtual MIDI device to receive the notes.
 
-1.  **A virtual MIDI driver:** This creates a virtual MIDI "cable."
-    *   **Windows:** [loopMIDI](https://www.tobias-erichsen.de/software/loopmidi.html) is a great, free option.
-    *   **macOS:** Use the built-in **Audio MIDI Setup** utility to create a virtual port with the IAC Driver.
-2.  **A synthesizer/DAW:** This is the instrument that will make sound.
-    *   Examples: GarageBand (macOS), Ableton Live, FL Studio, or a simple standalone synth.
+-   **Virtual MIDI Driver:**
+    -   **Windows:** [loopMIDI](https://www.tobias-erichsen.de/software/loopmidi.html)
+    -   **macOS:** Use the built-in **Audio MIDI Setup** utility (IAC Driver).
+-   **Synthesizer/DAW:**
+    -   Examples: GarageBand, Ableton Live, FL Studio.
 
-**Configuration:**
-- Create a virtual MIDI port. The application will create a port named `HandTrackingMidiController` by default.
-- Open your synthesizer and set its MIDI input to this virtual port.
+**Configuration:** Create a virtual MIDI port. Then, open your synthesizer and set its MIDI input to this virtual port. The app will create a port named `HandTrackingMidiController` by default.
 
----
+### 2. Running the Application
 
-### Option 1: Run as a Standalone Script
+#### Option A: Standalone Script
 
-This will open a new window to display the webcam feed.
+This opens a new window for the webcam feed.
 
 1.  **Run the script:**
     ```bash
     python main.py
     ```
 2.  **Control:**
-    - A window will appear showing the hand tracking.
-    - Move your hand up and down to play notes.
-    - Press the **'q'** key on your keyboard while the window is active to quit.
+    -   Move your hand **up and down** to play notes.
+    -   Move your hand **left and right** to change the modulation value (CC #1).
+    -   Press **'q'** to quit.
 
-### Option 2: Run with Jupyter Notebook
+#### Option B: Jupyter Notebook
 
-This is ideal for experimentation. The webcam feed will be displayed directly inside the notebook.
+This is ideal for experimentation, showing the feed directly in the notebook.
 
 1.  **Start Jupyter:**
     ```bash
     jupyter notebook
     ```
-2.  **Open `demo.ipynb`:**
-    - In the Jupyter interface in your browser, click on `demo.ipynb`.
-3.  **Follow the instructions:**
-    - The notebook contains detailed markdown cells and code cells.
-    - Run the cells in order to initialize, start, and stop the hand tracking.
+2.  **Open `demo.ipynb`** and run the cells in order. The notebook provides detailed instructions.
+
+## Customization
+
+You can customize the `HandMusicController` when you create an instance. For example, to control **Volume (CC #7)** instead of Modulation:
+
+```python
+from hand_tracking_module import HandMusicController
+
+# Control Volume (CC #7) with the X-axis
+controller = HandMusicController(cc_control_number=7)
+
+# Start the controller
+controller.start_window_display() # or start_notebook_display()
+```

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Hand Tracking Music Controller Demo\n",
     "\n",
-    "This notebook demonstrates how to use the `HandMusicController` to track your hand with a webcam and generate MIDI notes. The video feed will be displayed directly in the notebook."
+    "This notebook demonstrates how to use the `HandMusicController` to track your hand with a webcam. The **vertical position (Y-axis)** of your hand controls MIDI notes, while the **horizontal position (X-axis)** controls a MIDI CC (Control Change) value. The video feed will be displayed directly in the notebook."
    ]
   },
   {
@@ -53,7 +53,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, create an instance of the controller. If you named your virtual MIDI port something different, you can pass it as an argument here (e.g., `HandMusicController(midi_port_name='MyMIDIPort')`)."
+    "Now, create an instance of the controller. By default, the horizontal movement will control **CC #1 (Modulation)**. You can change this by passing the `cc_control_number` argument. For example, to control **Volume (CC #7)**, you would use:\n",
+    "\n",
+    "`controller = HandMusicController(cc_control_number=7)`"
    ]
   },
   {
@@ -62,6 +64,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# By default, the controller uses CC #1 (Modulation).\n",
+    "# To control a different CC, like Volume (CC #7), uncomment the line below:\n",
+    "# controller = HandMusicController(cc_control_number=7)\n",
+    "\n",
     "controller = HandMusicController()"
    ]
   },
@@ -71,9 +77,10 @@
    "source": [
     "## Step 3: Start Hand Tracking\n",
     "\n",
-    "The `start_notebook_display()` method will activate the webcam and start showing the video feed below. The hand tracking and MIDI note generation will begin immediately.\n",
+    "The `start_notebook_display()` method will activate the webcam and start showing the video feed below. The hand tracking and MIDI generation will begin immediately.\n",
     "\n",
-    "Place your hand in front of the camera to start playing notes!"
+    "- **Move your hand up and down** to change the MIDI note.\n",
+    "- **Move your hand left and right** to change the CC value."
    ]
   },
   {

--- a/hand_tracking_module.py
+++ b/hand_tracking_module.py
@@ -11,7 +11,7 @@ class HandMusicController:
     """
 
     def __init__(self, midi_port_name='HandTrackingMidiController', max_hands=1,
-                 detection_confidence=0.7, tracking_confidence=0.7):
+                 detection_confidence=0.7, tracking_confidence=0.7, cc_control_number=1):
         """
         Initializes the HandMusicController.
         Args:
@@ -19,11 +19,14 @@ class HandMusicController:
             max_hands (int): Maximum number of hands to detect.
             detection_confidence (float): Minimum confidence value for hand detection.
             tracking_confidence (float): Minimum confidence value for hand tracking.
+            cc_control_number (int): The MIDI CC number to control with the x-axis.
         """
         self.midi_port_name = midi_port_name
+        self.cc_control_number = cc_control_number
         self.midi_out_port = None
         self.running = False
         self.current_note = -1
+        self.current_cc_value = -1
 
         # Initialize MediaPipe Hands
         self.mp_hands = mp.solutions.hands
@@ -57,6 +60,10 @@ class HandMusicController:
         inverted_y = self.height - y
         return int((inverted_y / self.height) * 127)
 
+    def _map_x_to_cc_value(self, x):
+        """Maps an x-coordinate to a MIDI CC value."""
+        return int((x / self.width) * 127)
+
     def _process_frame(self, frame):
         """
         Processes a single frame for hand tracking and MIDI control.
@@ -70,6 +77,8 @@ class HandMusicController:
 
         if results.multi_hand_landmarks:
             hand_landmarks = results.multi_hand_landmarks[0]
+
+            # --- Note (Y-axis) Logic ---
             wrist_y = hand_landmarks.landmark[self.mp_hands.HandLandmark.WRIST].y * self.height
             note_to_play = self._map_y_to_note(wrist_y)
 
@@ -82,11 +91,22 @@ class HandMusicController:
 
                 self.current_note = note_to_play
 
+            # --- CC (X-axis) Logic ---
+            wrist_x = hand_landmarks.landmark[self.mp_hands.HandLandmark.WRIST].x * self.width
+            cc_value_to_send = self._map_x_to_cc_value(wrist_x)
+
+            if cc_value_to_send != self.current_cc_value and self.midi_out_port:
+                self.midi_out_port.send(mido.Message('control_change', control=self.cc_control_number, value=cc_value_to_send))
+                self.current_cc_value = cc_value_to_send
+
             # Drawing landmarks and info on the frame
             self.mp_drawing.draw_landmarks(frame, hand_landmarks, self.mp_hands.HAND_CONNECTIONS)
             cv2.putText(frame, f'Note: {self.current_note}', (10, 30),
                         cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2, cv2.LINE_AA)
+            cv2.putText(frame, f'CC {self.cc_control_number}: {self.current_cc_value}', (10, 70),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2, cv2.LINE_AA)
         else:
+            # If no hand is detected, turn off the current note
             if self.current_note != -1 and self.midi_out_port:
                 self.midi_out_port.send(mido.Message('note_off', note=self.current_note))
                 self.current_note = -1

--- a/main.py
+++ b/main.py
@@ -4,7 +4,10 @@ def main():
     """
     Initializes and runs the hand tracking music controller.
     """
-    # Create an instance of the controller
+    # Create an instance of the controller.
+    # By default, it controls CC #1 (Modulation).
+    # You can change this, for example, to control CC #7 (Volume):
+    # controller = HandMusicController(cc_control_number=7)
     controller = HandMusicController()
 
     # Start the controller with a window display.


### PR DESCRIPTION
This commit adds a new feature to the `HandMusicController` that allows the horizontal (X-axis) position of the hand to control a MIDI Control Change (CC) message.

- The CC number is configurable via the `cc_control_number` parameter in the constructor, defaulting to 1 (Modulation).
- The `_process_frame` method now extracts the hand's X-coordinate, maps it to a CC value (0-127), and sends a `control_change` MIDI message.
- The video feed is updated to display the current CC number and value.
- The `README.md`, `main.py`, and `demo.ipynb` files have been updated to document and demonstrate this new functionality.